### PR TITLE
[sandbox] Add initialization script

### DIFF
--- a/agent/Makefile
+++ b/agent/Makefile
@@ -1,2 +1,5 @@
+init-sandbox:
+	/usr/bin/env bash ./scripts/init-sandbox.sh
+
 rootfs:
 	./scripts/rootfs.sh

--- a/agent/scripts/init-sandbox.sh
+++ b/agent/scripts/init-sandbox.sh
@@ -1,0 +1,18 @@
+#!/usr/bin/env bash
+
+set -euo pipefail
+
+SANDBOX_ROOT_DIR=/var/lib/sandbox
+
+mkdir -p "$SANDBOX_ROOT_DIR"
+
+dirs=("images" "inner" "jobs")
+
+for dir in "${dirs[@]}"; do
+    if [ ! -d "$SANDBOX_ROOT_DIR/$dir" ]; then
+        echo "Creating directory $SANDBOX_ROOT_DIR/$dir"
+        mkdir -p "$SANDBOX_ROOT_DIR/$dir"
+    fi
+done
+
+DOCKER_IMAGE=ubuntu:latest DST_DIR="$SANDBOX_ROOT_DIR/images/ubuntu" scripts/rootfs.sh


### PR DESCRIPTION
Creates the `/var/lib/sandbox` directory for sandbox operations using the sandbox pkg

Usage:
```
sudo make init-sandbox 
```